### PR TITLE
Replace Pistache with Flask interface and expose core commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,6 @@ set (MANDEYE_VERSION "0.6-dev")
 message(STATUS "Mandeye version is : ${MANDEYE_VERSION}")
 
 set(SYSTEM_ARCH "${CMAKE_SYSTEM_PROCESSOR}")
-message("pistache")
-#pistache
-add_subdirectory(3rd/pistache)
-
-
 message("LASzip library")
 # LASzip library
 add_subdirectory(3rd/LASzip)
@@ -63,11 +58,16 @@ configure_file(
 # Include the generated file in the project
 include_directories(${CMAKE_BINARY_DIR})
 #executable
-add_executable(control_program code/main.cpp code/gnss.cpp code/web_page.h code/LivoxClient.cpp code/FileSystemClient.cpp code/save_laz.cpp ${PISTACHE_SRC}
+add_executable(control_program code/main.cpp code/gnss.cpp code/LivoxClient.cpp code/FileSystemClient.cpp code/save_laz.cpp
         code/utils/TimeStampReceiver.cpp code/publisher.cpp)
 set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -latomic")
 
-target_link_libraries(control_program pthread livox_lidar_sdk_static pistache atomic laszip ${LIBSERIAL_LIBRARY} minea zmq)
+target_link_libraries(control_program pthread livox_lidar_sdk_static atomic laszip ${LIBSERIAL_LIBRARY} minea zmq)
+
+add_library(mandeye_core SHARED code/main.cpp code/gnss.cpp code/LivoxClient.cpp code/FileSystemClient.cpp code/save_laz.cpp
+        code/utils/TimeStampReceiver.cpp code/publisher.cpp)
+target_link_libraries(mandeye_core pthread livox_lidar_sdk_static atomic laszip ${LIBSERIAL_LIBRARY} minea zmq)
+target_compile_definitions(mandeye_core PRIVATE MANDEYE_LIBRARY)
 # Define install directories
 install(TARGETS control_program
         RUNTIME DESTINATION /opt/mandeye/)

--- a/code/web_page.h
+++ b/code/web_page.h
@@ -1,5 +1,0 @@
-#pragma once
-
-#include "incbin.h"
-
-INCTXT(JQUERY, "../3rd/jquery-3.3.1.js");

--- a/web/app.py
+++ b/web/app.py
@@ -1,0 +1,49 @@
+import ctypes
+import os
+import atexit
+from flask import Flask, render_template
+
+LIB_PATH = os.path.join(os.path.dirname(__file__), '..', 'build', 'libmandeye_core.so')
+lib = ctypes.CDLL(LIB_PATH)
+
+lib.Init()
+atexit.register(lib.Shutdown)
+
+lib.StartScan.restype = ctypes.c_bool
+lib.StopScan.restype = ctypes.c_bool
+lib.TriggerStopScan.restype = ctypes.c_bool
+lib.produceReport.argtypes = [ctypes.c_bool]
+lib.produceReport.restype = ctypes.c_char_p
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    status = lib.produceReport(ctypes.c_bool(False)).decode('utf-8')
+    return render_template('index.html', status=status)
+
+@app.route('/status')
+def status():
+    return lib.produceReport(ctypes.c_bool(False)).decode('utf-8')
+
+@app.route('/status_full')
+def status_full():
+    return lib.produceReport(ctypes.c_bool(True)).decode('utf-8')
+
+@app.route('/start_scan')
+def start_scan():
+    lib.StartScan()
+    return '', 204
+
+@app.route('/stop_scan')
+def stop_scan():
+    lib.StopScan()
+    return '', 204
+
+@app.route('/stopscan')
+def stopscan():
+    lib.TriggerStopScan()
+    return '', 204
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Mandeye</title>
+    <script>
+      function updateStatus(){
+        fetch('/status').then(r=>r.text()).then(t=>document.getElementById('status').textContent=t);
+      }
+      function call(url){ fetch(url); }
+      setInterval(updateStatus, 5000);
+    </script>
+  </head>
+  <body onload="updateStatus()">
+    <h1>Mandeye Status</h1>
+    <pre id="status">{{ status }}</pre>
+    <button onclick="call('/start_scan')">Start Scan</button>
+    <button onclick="call('/stop_scan')">Stop Scan</button>
+    <button onclick="call('/stopscan')">Trigger Stop Scan</button>
+    <button onclick="updateStatus()">Refresh Status</button>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- remove Pistache server and embedded web assets
- expose StartScan/StopScan/TriggerStopScan/produceReport via C API and new shared library
- add Flask app with simple HTML frontend for status and scan control

## Testing
- `cmake .. && make mandeye_core` *(fails: The source directory `/workspace/mandeye_tec/3rd/LASzip` does not contain a CMakeLists.txt file)*
- `python -m py_compile web/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68972bea0d7c832a85f45720042bfd50