### PR TITLE
Refactor web app with API/UI blueprints and Vue status dashboard

### DIFF
--- a/web/api.py
+++ b/web/api.py
@@ -1,0 +1,59 @@
+import ctypes
+import json
+import zmq
+from flask import Blueprint, Response, jsonify, current_app
+from backend import lib, status_cache
+
+api_bp = Blueprint('api', __name__, url_prefix='/api')
+
+
+@api_bp.route('/status')
+def status():
+    return jsonify(status_cache)
+
+
+@api_bp.route('/status_full')
+def status_full():
+    raw = lib.produceReport(ctypes.c_bool(True)).decode("utf-8")
+    return jsonify(json.loads(raw))
+
+
+@api_bp.route('/start_scan', methods=['POST'])
+def start_scan():
+    if lib.StartScan():
+        return '', 204
+    return jsonify({'error': 'unable to start scan'}), 400
+
+
+@api_bp.route('/stop_scan', methods=['POST'])
+def stop_scan():
+    if lib.StopScan():
+        return '', 204
+    return jsonify({'error': 'unable to stop scan'}), 400
+
+
+@api_bp.route('/stopscan', methods=['POST'])
+def stopscan():
+    if lib.TriggerStopScan():
+        return '', 204
+    return jsonify({'error': 'unable to trigger stop scan'}), 400
+
+
+def zmq_event_stream(port):
+    context = zmq.Context()
+    socket = context.socket(zmq.SUB)
+    socket.connect(f"tcp://localhost:{port}")
+    socket.setsockopt_string(zmq.SUBSCRIBE, '')
+    try:
+        while True:
+            message = socket.recv_string()
+            yield f"data: {message}\n\n"
+    finally:
+        socket.close()
+        context.term()
+
+
+@api_bp.route('/stream')
+def stream():
+    port = current_app.config.get('server_port', 8003)
+    return Response(zmq_event_stream(port), mimetype='text/event-stream')

--- a/web/app.py
+++ b/web/app.py
@@ -1,84 +1,13 @@
-import ctypes
 import os
-import atexit
-import json
-import threading
-import time
-from flask import Flask, render_template, jsonify
-
-CONFIG_PATH = os.path.join(os.path.dirname(__file__), '..', 'config', 'mandeye_config.json')
-
-
-def load_config():
-    try:
-        with open(CONFIG_PATH) as f:
-            return json.load(f)
-    except OSError:
-        return {}
-
-
-config = load_config()
-
-LIB_PATH = os.path.join(os.path.dirname(__file__), '..', 'build', 'libmandeye_core.so')
-lib = ctypes.CDLL(LIB_PATH)
-
-lib.Init()
-atexit.register(lib.Shutdown)
-
-lib.StartScan.restype = ctypes.c_bool
-lib.StopScan.restype = ctypes.c_bool
-lib.TriggerStopScan.restype = ctypes.c_bool
-lib.produceReport.argtypes = [ctypes.c_bool]
-lib.produceReport.restype = ctypes.c_char_p
-
-# cache for status information updated in the background
-status_cache = {}
-
-
-def poll_status():
-    """Poll the C++ layer for status information."""
-    global status_cache
-    while True:
-        raw = lib.produceReport(ctypes.c_bool(True)).decode("utf-8")
-        try:
-            status_cache = json.loads(raw)
-        except json.JSONDecodeError:
-            status_cache = {}
-        time.sleep(1)
-
-
-threading.Thread(target=poll_status, daemon=True).start()
+from flask import Flask
+from backend import config
+from api import api_bp
+from ui import ui_bp
 
 app = Flask(__name__)
 app.config.update(config)
-
-@app.route('/')
-def index():
-    return render_template('index.html')
-
-@app.route('/status')
-def status():
-    return jsonify(status_cache)
-
-@app.route('/status_full')
-def status_full():
-    raw = lib.produceReport(ctypes.c_bool(True)).decode("utf-8")
-    return jsonify(json.loads(raw))
-
-@app.route('/start_scan')
-def start_scan():
-    lib.StartScan()
-    return '', 204
-
-@app.route('/stop_scan')
-def stop_scan():
-    lib.StopScan()
-    return '', 204
-
-@app.route('/stopscan')
-def stopscan():
-    lib.TriggerStopScan()
-    return '', 204
+app.register_blueprint(api_bp)
+app.register_blueprint(ui_bp)
 
 if __name__ == '__main__':
     port = config.get('web_port')

--- a/web/backend.py
+++ b/web/backend.py
@@ -1,0 +1,47 @@
+import ctypes
+import os
+import atexit
+import json
+import threading
+import time
+
+CONFIG_PATH = os.path.join(os.path.dirname(__file__), '..', 'config', 'mandeye_config.json')
+
+
+def load_config():
+    try:
+        with open(CONFIG_PATH) as f:
+            return json.load(f)
+    except OSError:
+        return {}
+
+
+config = load_config()
+
+LIB_PATH = os.path.join(os.path.dirname(__file__), '..', 'build', 'libmandeye_core.so')
+lib = ctypes.CDLL(LIB_PATH)
+
+lib.Init()
+atexit.register(lib.Shutdown)
+
+lib.StartScan.restype = ctypes.c_bool
+lib.StopScan.restype = ctypes.c_bool
+lib.TriggerStopScan.restype = ctypes.c_bool
+lib.produceReport.argtypes = [ctypes.c_bool]
+lib.produceReport.restype = ctypes.c_char_p
+
+status_cache = {}
+
+
+def poll_status():
+    global status_cache
+    while True:
+        raw = lib.produceReport(ctypes.c_bool(True)).decode("utf-8")
+        try:
+            status_cache = json.loads(raw)
+        except json.JSONDecodeError:
+            status_cache = {}
+        time.sleep(1)
+
+
+threading.Thread(target=poll_status, daemon=True).start()

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1,40 +1,86 @@
 <!doctype html>
 <html>
   <head>
-    <title>Mandeye</title>
-    <script>
-      function updateStatus(){
-        fetch('/status')
-          .then(r => r.json())
-          .then(data => {
-            document.getElementById('livox').textContent = JSON.stringify(data.livox, null, 2);
-            document.getElementById('gnss').textContent = JSON.stringify(data.gnss, null, 2);
-            document.getElementById('fs').textContent = JSON.stringify(data.fs || {}, null, 2);
-            document.getElementById('status').textContent = JSON.stringify(data, null, 2);
-          });
-      }
-      function call(url){ fetch(url); }
-      setInterval(updateStatus, 1000);
-    </script>
+    <meta charset="utf-8" />
+    <title>Mandeye Control</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+    <script src="https://cdn.jsdelivr.net/npm/vue@3.4.21/dist/vue.global.prod.js"></script>
   </head>
-  <body onload="updateStatus()">
-    <h1>Mandeye Status</h1>
+  <body>
+    <div id="app" class="container py-4">
+      <h1 class="mb-4">Mandeye Status</h1>
 
-    <h2>Lidar</h2>
-    <pre id="livox"></pre>
+      <div v-if="error" class="alert alert-danger" role="alert">{{ error }}</div>
+      <div v-if="message" class="alert alert-success" role="alert">{{ message }}</div>
 
-    <h2>GNSS</h2>
-    <pre id="gnss"></pre>
+      <div class="mb-3">
+        <button class="btn btn-primary me-2" @click="sendCommand('/api/start_scan')">Start Scan</button>
+        <button class="btn btn-warning me-2" @click="sendCommand('/api/stop_scan')">Stop Scan</button>
+        <button class="btn btn-danger" @click="sendCommand('/api/stopscan')">Trigger Stop Scan</button>
+      </div>
 
-    <h2>Filesystem</h2>
-    <pre id="fs"></pre>
+      <div class="row">
+        <div class="col-md-4">
+          <h2>Lidar</h2>
+          <pre>{{ format(status.livox) }}</pre>
+        </div>
+        <div class="col-md-4">
+          <h2>GNSS</h2>
+          <pre>{{ format(status.gnss) }}</pre>
+        </div>
+        <div class="col-md-4">
+          <h2>Filesystem</h2>
+          <pre>{{ format(status.fs) }}</pre>
+        </div>
+      </div>
 
-    <h2>Full Status</h2>
-    <pre id="status"></pre>
+      <div class="mt-4">
+        <h2>Scan Info</h2>
+        <p>Mode: {{ stream.mode || status.state }}</p>
+        <p>Elapsed: {{ Math.round((stream.dur||0)/1e9) }} s</p>
+        <p>Last Saved File: {{ status.lastLazStatus && status.lastLazStatus.filename || 'N/A' }}</p>
+        <p class="text-danger" v-if="status.state && status.state.includes('ERROR')">Error: {{ status.state }}</p>
+      </div>
+    </div>
 
-    <button onclick="call('/start_scan')">Start Scan</button>
-    <button onclick="call('/stop_scan')">Stop Scan</button>
-    <button onclick="call('/stopscan')">Trigger Stop Scan</button>
-    <button onclick="updateStatus()">Refresh Status</button>
+    <script>
+      const { createApp } = Vue;
+      createApp({
+        data() {
+          return { status: {}, stream: {}, error: '', message: '' };
+        },
+        methods: {
+          format(obj) {
+            return JSON.stringify(obj || {}, null, 2);
+          },
+          updateStatus() {
+            fetch('/api/status')
+              .then(r => r.json())
+              .then(data => { this.status = data; });
+          },
+          sendCommand(url) {
+            fetch(url, { method: 'POST' })
+              .then(r => {
+                if (!r.ok) throw new Error('Command failed');
+                this.message = 'Command successful';
+                setTimeout(() => this.message = '', 3000);
+              })
+              .catch(err => {
+                this.error = err.message;
+                setTimeout(() => this.error = '', 3000);
+              });
+          }
+        },
+        mounted() {
+          this.updateStatus();
+          setInterval(this.updateStatus, 5000);
+
+          const source = new EventSource('/api/stream');
+          source.onmessage = e => {
+            try { this.stream = JSON.parse(e.data); } catch (err) {}
+          };
+        }
+      }).mount('#app');
+    </script>
   </body>
 </html>

--- a/web/ui.py
+++ b/web/ui.py
@@ -1,0 +1,8 @@
+from flask import Blueprint, render_template
+
+ui_bp = Blueprint('ui', __name__)
+
+
+@ui_bp.route('/')
+def index():
+    return render_template('index.html')


### PR DESCRIPTION
## Summary
- Split Flask server into API and UI blueprints and centralized backend init
- Added `/api/stream` SSE endpoint relaying ZeroMQ publisher output
- Replaced index with Bootstrap/Vue dashboard showing device status and controls

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68975dc08fdc832aab887fec6ea82100