### PR TITLE
Add build and deployment helper scripts

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="${SCRIPT_DIR}/.."
+BUILD_DIR="${ROOT_DIR}/build"
+
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
+cmake ..
+make

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_DIR="${1:-/opt/mandeye}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="${SCRIPT_DIR}/.."
+BUILD_DIR="${ROOT_DIR}/build"
+CONFIG_DIR="${ROOT_DIR}/config"
+
+if [ ! -d "$BUILD_DIR" ]; then
+  echo "Build directory not found. Run scripts/build.sh first." >&2
+  exit 1
+fi
+
+sudo mkdir -p "$TARGET_DIR"
+sudo cp -r "$BUILD_DIR" "$TARGET_DIR/"
+sudo cp -r "$CONFIG_DIR" "$TARGET_DIR/"
+
+echo "Deployed build and config to $TARGET_DIR"

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sudo apt-get update
+sudo apt-get install -y build-essential cmake libserial-dev libzmq3-dev python3 python3-pip

--- a/scripts/run_web.sh
+++ b/scripts/run_web.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="${SCRIPT_DIR}/.."
+BUILD_DIR="${ROOT_DIR}/build"
+LIB_FILE="${BUILD_DIR}/libmandeye_core.so"
+
+if [ ! -f "$LIB_FILE" ]; then
+  echo "Error: $LIB_FILE not found. Please build the project first." >&2
+  exit 1
+fi
+
+WEB_PORT="${WEB_PORT:-5000}"
+export WEB_PORT
+
+cd "${ROOT_DIR}/web"
+python3 app.py


### PR DESCRIPTION
## Summary
- add install_dependencies.sh for installing build packages
- add build.sh to configure and compile the project
- add run_web.sh to verify shared library and run Flask web server
- add deploy.sh to copy build artifacts and config to target directory

## Testing
- `bash -n scripts/install_dependencies.sh scripts/build.sh scripts/run_web.sh scripts/deploy.sh`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68975f792890832abccfd4cc2b3a163d