### PR TITLE
Add Docker support with build and run scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:22.04
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && \
+    apt-get install -y git build-essential cmake libserial-dev libzmq3-dev python3 python3-pip && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy dependency definitions and install Python deps
+COPY requirements.txt ./
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+# Copy source code
+COPY . .
+
+# Fetch submodules and build the project
+RUN git submodule update --init --recursive && ./scripts/build.sh
+
+# Expose the web interface port
+EXPOSE 5000
+
+CMD ["./scripts/run_web.sh"]

--- a/README.md
+++ b/README.md
@@ -17,3 +17,16 @@ For each setting the application uses the following precedence:
 
 Edit the configuration file or set environment variables as needed before
 starting the application.
+
+## Docker
+
+The project can be built and run in a container:
+
+```bash
+scripts/build_docker.sh
+scripts/run_docker.sh
+```
+
+The run script exposes the web interface on port `5000` and mounts the
+`config` directory into the container so you can edit `config/mandeye_config.json`
+on the host and have those settings applied inside the container.

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="${SCRIPT_DIR}/.."
+
+IMAGE_NAME="mandeye_tec:latest"
+
+docker build -t "$IMAGE_NAME" "$ROOT_DIR"

--- a/scripts/run_docker.sh
+++ b/scripts/run_docker.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="${SCRIPT_DIR}/.."
+
+IMAGE_NAME="mandeye_tec:latest"
+CONFIG_DIR="${ROOT_DIR}/config"
+
+# Map web port and configuration directory
+WEB_PORT="${WEB_PORT:-5000}"
+
+docker run --rm -it -p "$WEB_PORT:$WEB_PORT" -v "${CONFIG_DIR}:/app/config" "$IMAGE_NAME"


### PR DESCRIPTION
## Summary
- Provide Dockerfile that installs dependencies, builds the project and exposes the web UI
- Add helper scripts to build and run the Docker container with the config directory mounted
- Document container usage and mounting instructions in README

## Testing
- `./scripts/build.sh` *(fails: 'json' was not declared in this scope)*

------
https://chatgpt.com/codex/tasks/task_e_689766017d98832a9c36849df45801d3