### PR TITLE
Require prebuilt Livox SDK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,20 @@ message("JSON")
 #JSON
 include_directories(3rd/json)
 
-message("Livox SDK2")
-# Livox SDK2
-add_subdirectory(3rd/Livox-SDK2)
+# Livox SDK2 (precompiled)
+# The Livox SDK must be compiled and installed manually before building
+# this project.  Provide the installation prefix via LIVOX_SDK_DIR or
+# install to a standard system location such as /usr/local.
+set(LIVOX_SDK_DIR "" CACHE PATH "Path to Livox SDK2 installation")
+find_path(LIVOX_SDK_INCLUDE_DIR livox_lidar_def.h
+        HINTS ${LIVOX_SDK_DIR}/include
+        PATHS /usr/local/include /usr/include
+        REQUIRED)
+find_library(LIVOX_SDK_LIBRARY livox_lidar_sdk_static
+        HINTS ${LIVOX_SDK_DIR}/lib
+        PATHS /usr/local/lib /usr/lib
+        REQUIRED)
+include_directories(${LIVOX_SDK_INCLUDE_DIR})
 
 include_directories(code/)
 
@@ -55,11 +66,11 @@ add_executable(control_program code/main.cpp code/gnss.cpp code/LivoxClient.cpp 
         code/utils/TimeStampReceiver.cpp code/publisher.cpp code/utils/logger.cpp)
 set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -latomic")
 
-target_link_libraries(control_program pthread livox_lidar_sdk_static atomic laszip ${LIBSERIAL_LIBRARY} minea zmq)
+target_link_libraries(control_program pthread ${LIVOX_SDK_LIBRARY} atomic laszip ${LIBSERIAL_LIBRARY} minea zmq)
 
 add_library(mandeye_core SHARED code/main.cpp code/gnss.cpp code/LivoxClient.cpp code/FileSystemClient.cpp code/save_laz.cpp
         code/utils/TimeStampReceiver.cpp code/publisher.cpp code/utils/logger.cpp)
-target_link_libraries(mandeye_core pthread livox_lidar_sdk_static atomic laszip ${LIBSERIAL_LIBRARY} minea zmq)
+target_link_libraries(mandeye_core pthread ${LIVOX_SDK_LIBRARY} atomic laszip ${LIBSERIAL_LIBRARY} minea zmq)
 target_compile_definitions(mandeye_core PRIVATE MANDEYE_LIBRARY)
 # Define install directories
 install(TARGETS control_program

--- a/README.md
+++ b/README.md
@@ -44,17 +44,30 @@ The project relies on the following packages (installed by
    scripts/install_dependencies.sh
    ```
 
-2. Build the C++ core:
+2. Compile and install the Livox SDK2 (required before building):
+
+   ```bash
+   git submodule update --init --recursive 3rd/Livox-SDK2
+   cd 3rd/Livox-SDK2
+   mkdir build && cd build
+   cmake .. && make -j
+   sudo make install  # installs headers and libs to /usr/local
+   ```
+
+   If you install to a non-standard prefix, set `LIVOX_SDK_DIR` to that
+   location before running the build script.
+
+3. Build the C++ core:
 
    ```bash
    scripts/build.sh
    ```
 
-3. Edit configuration settings in
+4. Edit configuration settings in
    [`config/mandeye_config.json`](config/mandeye_config.json) to match your
    environment (see **Configuration** below).
 
-4. Launch the web interface:
+5. Launch the web interface:
 
    ```bash
    scripts/run_web.sh

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,5 +7,14 @@ BUILD_DIR="${ROOT_DIR}/build"
 
 mkdir -p "$BUILD_DIR"
 cd "$BUILD_DIR"
-cmake ..
+if [[ -n "${LIVOX_SDK_DIR:-}" ]]; then
+  if [[ ! -f "${LIVOX_SDK_DIR}/lib/liblivox_lidar_sdk_static.a" ]]; then
+    echo "Livox SDK not found in ${LIVOX_SDK_DIR}." >&2
+    echo "Please compile Livox SDK2 and set LIVOX_SDK_DIR to its installation path." >&2
+    exit 1
+  fi
+  cmake -DLIVOX_SDK_DIR="${LIVOX_SDK_DIR}" ..
+else
+  cmake ..
+fi
 make


### PR DESCRIPTION
## Summary
- Switch CMake to link against an already-installed Livox SDK2 and expose `LIVOX_SDK_DIR` for custom locations
- Update build script to validate `LIVOX_SDK_DIR` and forward it to CMake
- Document manual Livox SDK2 build/install in README

## Testing
- `make -j` (failed: `'uint64_t' does not name a type` in Livox SDK2)
- `LIVOX_SDK_DIR=/workspace/mandeye_tec/3rd/Livox-SDK2/build scripts/build.sh` (failed: Livox SDK not found)


------
https://chatgpt.com/codex/tasks/task_e_68983aa706d8832abf0db0157a1faf95