### PR TITLE
Add USB automount setup script and installation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ API for remote control.
 ### Software
 
 The project relies on the following packages (installed by
-`scripts/install_dependencies.sh`):
+`scripts/install.sh`):
 
 * `build-essential`, `cmake`
 * `libserial-dev`, `libzmq3-dev`
@@ -38,11 +38,13 @@ The project relies on the following packages (installed by
 
 ## Installation
 
-1. Install system and Python dependencies:
+1. Install system and Python dependencies and configure USB automounting:
 
    ```bash
-   scripts/install_dependencies.sh
+   scripts/install.sh
    ```
+
+   Reboot after this step to enable USB automounting.
 
 2. Compile and install the Livox SDK2 (required before building):
 
@@ -126,8 +128,8 @@ curl http://localhost:5000/api/status_full  # detailed
 
 * **Build errors** – ensure all dependencies are installed and required
   third‑party sources (e.g. LASzip) are present. Running
-  `scripts/install_dependencies.sh` and fetching git submodules usually
-  resolves missing headers.
+  `scripts/install.sh` and fetching git submodules usually resolves
+  missing headers.
 * **`libmandeye_core.so not found`** – run `scripts/build.sh` before
   executing `scripts/run_web.sh`.
 * **Device connectivity issues** – verify network settings for the lidar

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"${SCRIPT_DIR}/install_dependencies.sh"
+"${SCRIPT_DIR}/setup_usb_mount.sh"
+
+echo "Installation complete. Please reboot the system for USB automount configuration to take effect."

--- a/scripts/setup_usb_mount.sh
+++ b/scripts/setup_usb_mount.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install usbmount and exFAT support
+sudo apt-get update
+sudo apt-get install -y usbmount exfat-fuse exfat-utils
+
+USBMOUNT_CONF=/etc/usbmount/usbmount.conf
+if [[ -f "$USBMOUNT_CONF" ]]; then
+  # Configure mount options and supported filesystems
+  sudo sed -i 's|^MOUNTOPTIONS=.*|MOUNTOPTIONS="sync,noexec,nodev,noatime,uid=1000,gid=1000"|' "$USBMOUNT_CONF"
+  sudo sed -i 's|^FILESYSTEMS=.*|FILESYSTEMS="vfat ext2 ext3 ext4 hfsplus ntfs fuseblk exfat"|' "$USBMOUNT_CONF"
+else
+  echo "usbmount configuration file not found at $USBMOUNT_CONF" >&2
+  exit 1
+fi
+
+# Ensure usbmount works with systemd's PrivateMounts
+sudo mkdir -p /etc/systemd/system/systemd-udevd.service.d
+sudo tee /etc/systemd/system/systemd-udevd.service.d/usbmount.conf > /dev/null <<'EOC'
+[Service]
+PrivateMounts=no
+EOC
+
+sudo systemctl daemon-reload
+
+echo "USB automount configured. Reboot required to apply changes."


### PR DESCRIPTION
## Summary
- add `scripts/setup_usb_mount.sh` to install/configure usbmount with exfat support and systemd override for PrivateMounts
- add `scripts/install.sh` orchestrating dependency and USB setup and prompting reboot
- document new install flow and reboot requirement in README

## Testing
- `shellcheck scripts/setup_usb_mount.sh scripts/install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68984597c950832a9dbff73a2ecef910