### PR TITLE
Serve web UI as static file

### DIFF
--- a/web/ui.py
+++ b/web/ui.py
@@ -1,8 +1,10 @@
-from flask import Blueprint, render_template
+import os
+from flask import Blueprint, send_from_directory
 
 ui_bp = Blueprint('ui', __name__)
+_TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), 'templates')
 
 
 @ui_bp.route('/')
 def index():
-    return render_template('index.html')
+    return send_from_directory(_TEMPLATE_DIR, 'index.html')


### PR DESCRIPTION
## Summary
- Serve index.html via send_from_directory to prevent Jinja parsing errors

## Testing
- `python -m py_compile web/ui.py`
- `python - <<'PY'
from flask import Flask
from web.ui import ui_bp
app = Flask(__name__)
app.register_blueprint(ui_bp)
with app.test_client() as c:
    resp = c.get('/')
    print('status', resp.status_code)
    print(resp.data.decode('utf-8')[:60])
PY`


------
https://chatgpt.com/codex/tasks/task_e_689857842e9c832a86c469283eddc084