### PR TITLE
Auto-detect Livox interface IP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,13 +86,15 @@ configure_file(
 include_directories(${CMAKE_BINARY_DIR})
 #executable
 add_executable(control_program code/main.cpp code/gnss.cpp code/LivoxClient.cpp code/FileSystemClient.cpp code/save_laz.cpp
-        code/utils/TimeStampReceiver.cpp code/publisher.cpp code/utils/logger.cpp)
+        code/utils/TimeStampReceiver.cpp code/publisher.cpp code/utils/logger.cpp
+        code/utils/network.cpp)
 set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -latomic")
 
 target_link_libraries(control_program pthread ${LIVOX_SDK_LIBRARY} atomic laszip ${LIBSERIAL_LIBRARY} minea zmq)
 
 add_library(mandeye_core SHARED code/main.cpp code/gnss.cpp code/LivoxClient.cpp code/FileSystemClient.cpp code/save_laz.cpp
-        code/utils/TimeStampReceiver.cpp code/publisher.cpp code/utils/logger.cpp)
+        code/utils/TimeStampReceiver.cpp code/publisher.cpp code/utils/logger.cpp
+        code/utils/network.cpp)
 target_link_libraries(mandeye_core pthread ${LIVOX_SDK_LIBRARY} atomic laszip ${LIBSERIAL_LIBRARY} minea zmq)
 target_compile_definitions(mandeye_core PRIVATE MANDEYE_LIBRARY)
 # Define install directories

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ The project relies on the following packages (installed by
 Runtime settings are loaded from `config/mandeye_config.json` at startup. The
 file supports the following fields:
 
-* `livox_interface_ip` – Livox interface IP address (default
-  `"192.168.1.5"`).
+* `livox_interface_ip` – Livox interface IP address (default auto-detected
+  from the available network interfaces).
 * `repository_path` – Path to USB repository (default `"/media/usb/"`).
 * `server_port` – Port used by the C++ publisher (default `8003`).
 * `web_port` – Port for the Flask web UI (default `5000`).

--- a/code/main.cpp
+++ b/code/main.cpp
@@ -13,9 +13,9 @@
 #include <chrono>
 #include <fstream>
 #include "utils/logger.h"
+#include "utils/network.h"
 #include <string>
 
-#define MANDEYE_LIVOX_LISTEN_IP "192.168.1.5"
 #define MANDEYE_REPO "/media/usb/"
 #define SERVER_PORT 8003
 
@@ -28,7 +28,7 @@ int getEnvInt(const std::string& env, int def);
 
 struct MandeyeConfig
 {
-        std::string livox_interface_ip = MANDEYE_LIVOX_LISTEN_IP;
+        std::string livox_interface_ip = utils::getInterfaceIp();
         std::string repository_path = MANDEYE_REPO;
         int server_port = SERVER_PORT;
 };

--- a/code/utils/network.cpp
+++ b/code/utils/network.cpp
@@ -1,0 +1,47 @@
+#include "network.h"
+#include <ifaddrs.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+
+namespace utils
+{
+        std::string getInterfaceIp()
+        {
+                struct ifaddrs* ifaddr = nullptr;
+                std::string ip;
+                if(getifaddrs(&ifaddr) != 0)
+                {
+                        return ip;
+                }
+                for(struct ifaddrs* ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
+                {
+                        if(ifa->ifa_addr == nullptr)
+                        {
+                                continue;
+                        }
+                        if(ifa->ifa_addr->sa_family == AF_INET)
+                        {
+                                char addr[INET_ADDRSTRLEN];
+                                auto* in = reinterpret_cast<sockaddr_in*>(ifa->ifa_addr);
+                                if(inet_ntop(AF_INET, &in->sin_addr, addr, sizeof(addr)))
+                                {
+                                        std::string candidate(addr);
+                                        if(candidate.rfind("192.168.", 0) == 0)
+                                        {
+                                                ip = candidate;
+                                                break;
+                                        }
+                                        if(ip.empty())
+                                        {
+                                                ip = candidate;
+                                        }
+                                }
+                        }
+                }
+                if(ifaddr)
+                {
+                        freeifaddrs(ifaddr);
+                }
+                return ip;
+        }
+} // namespace utils

--- a/code/utils/network.h
+++ b/code/utils/network.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <string>
+
+namespace utils
+{
+        std::string getInterfaceIp();
+}
+


### PR DESCRIPTION
## Summary
- add utility to obtain IPv4 address of Livox-facing interface
- initialize configuration with detected interface IP and pass to LivoxClient
- document auto-detected IP configuration

## Testing
- `cmake -S . -B build` *(fails: Could not find LIVOX_SDK_INCLUDE_DIR)*

------
https://chatgpt.com/codex/tasks/task_e_68985d49339c832aa9cfa0fb221e50c3