### PR TITLE
Improve deployment and network scripts

### DIFF
--- a/scripts/ds_setup_static_ip.sh
+++ b/scripts/ds_setup_static_ip.sh
@@ -1,16 +1,58 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
-CON_NAME="Wired connection 1"
-if ! nmcli -g NAME con show | grep -Fx "$CON_NAME" >/dev/null 2>&1; then
-  echo "Creating NetworkManager connection $CON_NAME..."
-  sudo nmcli con add type ethernet ifname eth0 con-name "$CON_NAME"
+# Configure a persistent static IP of 192.168.6.1/24 on eth0.
+# Supports systems using netplan, systemd-networkd, or dhcpcd. The script
+# is idempotent and will not duplicate configuration if re-run.
+
+if command -v netplan >/dev/null 2>&1; then
+  CONFIG_FILE="/etc/netplan/10-eth0-static.yaml"
+  if [[ ! -f "$CONFIG_FILE" ]]; then
+    echo "Creating netplan configuration at $CONFIG_FILE"
+    sudo tee "$CONFIG_FILE" >/dev/null <<'EOF'
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    eth0:
+      dhcp4: no
+      addresses: [192.168.6.1/24]
+EOF
+    sudo netplan apply
+  else
+    echo "Netplan configuration already exists at $CONFIG_FILE"
+  fi
+elif systemctl list-unit-files 2>/dev/null | grep -q systemd-networkd; then
+  CONFIG_FILE="/etc/systemd/network/10-eth0.network"
+  if [[ ! -f "$CONFIG_FILE" ]]; then
+    echo "Creating systemd-networkd configuration at $CONFIG_FILE"
+    sudo tee "$CONFIG_FILE" >/dev/null <<'EOF'
+[Match]
+Name=eth0
+
+[Network]
+Address=192.168.6.1/24
+EOF
+    sudo systemctl restart systemd-networkd
+  else
+    echo "systemd-networkd configuration already exists at $CONFIG_FILE"
+  fi
+elif command -v dhcpcd >/dev/null 2>&1; then
+  CONFIG_FILE="/etc/dhcpcd.conf"
+  if ! sudo grep -q "^interface eth0" "$CONFIG_FILE"; then
+    echo "Appending dhcpcd configuration to $CONFIG_FILE"
+    sudo tee -a "$CONFIG_FILE" >/dev/null <<'EOF'
+interface eth0
+static ip_address=192.168.6.1/24
+nohook wpa_supplicant
+EOF
+    sudo systemctl restart dhcpcd
+  else
+    echo "dhcpcd configuration for eth0 already present in $CONFIG_FILE"
+  fi
+else
+  echo "No supported network configuration system found (netplan, systemd-networkd, dhcpcd)" >&2
+  exit 1
 fi
 
-echo "Configuring static IP 192.168.6.1 on $CON_NAME..."
-sudo nmcli con mod "$CON_NAME" ipv4.method manual ipv4.addresses 192.168.6.1/24
-sudo nmcli con mod "$CON_NAME" ipv4.gateway ""
-sudo nmcli con mod "$CON_NAME" ipv4.dns ""
-sudo nmcli con mod "$CON_NAME" connection.autoconnect yes
-sudo nmcli con mod "$CON_NAME" connection.interface-name eth0
-sudo nmcli con up "$CON_NAME"
+echo "Static IP configuration complete."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,19 +13,34 @@ steps=(
   "Build main application|ds_build_app.sh"
 )
 
+non_interactive=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --yes|-y)
+      non_interactive=true
+      shift
+      ;;
+    *)
+      echo "Usage: $0 [--yes]" >&2
+      exit 1
+      ;;
+  esac
+done
+
 for step in "${steps[@]}"; do
   desc=${step%%|*}
   script=${step##*|}
-  read -rp "Run step: $desc? [y/N] " ans
+  if $non_interactive; then
+    ans="y"
+  else
+    read -rp "Run step: $desc? [y/N] " ans
+  fi
   if [[ "$ans" =~ ^[Yy]$ ]]; then
     "${SCRIPT_DIR}/${script}"
   else
     echo "Skipping $desc"
   fi
   echo
-  read -rp "Press Enter to continue..." _
-  echo
-
 done
 
 echo "Installation complete. Please reboot if system components were installed."


### PR DESCRIPTION
## Summary
- allow `scripts/install.sh` to run non-interactively with `--yes` and remove redundant pauses
- make `ds_setup_static_ip.sh` create persistent netplan/networkd/dhcpcd config idempotently
- skip `ds_deploy.sh` when target is up to date unless `--force`

## Testing
- `bash -n scripts/install.sh`
- `bash -n scripts/ds_setup_static_ip.sh`
- `bash -n scripts/ds_deploy.sh`


------
https://chatgpt.com/codex/tasks/task_e_689a0f3f2284832aaf0cb11893e9e353