### PR TITLE
Improve stop recording flow

### DIFF
--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -163,22 +163,32 @@
           });
           const res = await fetch('/api/start_scan',{method:'POST'});
           const data = res.status === 204 ? {status:'started'} : await res.json();
-          showMessage(res.ok, data.status || 'started');
+          showMessage(res.ok, data.status || data.error || 'started');
         } catch(err){
-          showMessage(false, 'failed to contact server');
+          showMessage(false, err.message || 'failed to contact server');
         }
         await updateStatusAndRecordings();
       }
 
       async function stopRec(){
         try {
-          const res = await fetch('/api/stop_scan',{method:'POST'});
-          const data = res.status === 204 ? {status:'stopped'} : await res.json();
-          showMessage(res.ok, data.status || 'stopped');
+          let res = await fetch('/api/stop_scan',{method:'POST'});
+          let data = res.status === 204 ? {status:'stopped'} : await res.json();
+          showMessage(res.ok, data.status || data.error || 'stopped');
+          if(!res.ok){
+            res = await fetch('/api/stopscan',{method:'POST'});
+            data = res.status === 204 ? {status:'stopped'} : await res.json();
+            showMessage(res.ok, data.status || data.error || 'stopped');
+          }
         } catch(err){
-          showMessage(false, 'failed to contact server');
+          showMessage(false, err.message || 'failed to contact server');
         }
-        await updateStatusAndRecordings();
+        try {
+          await updateStatusAndRecordings();
+        } finally {
+          document.getElementById('start_btn').disabled = false;
+          document.getElementById('stop_btn').disabled = true;
+        }
       }
 
       function showMessage(success, message){


### PR DESCRIPTION
## Summary
- Add fallback to `/api/stopscan` when `/api/stop_scan` fails and surface backend errors
- Always re-enable start button after stopping
- Surface backend error responses when starting a scan

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a21263ef8832ab469b5fb33a1dc95