### PR TITLE
Remove stop-scan option from controller

### DIFF
--- a/web/api.py
+++ b/web/api.py
@@ -37,13 +37,6 @@ def stop_scan():
     return jsonify({'error': 'unable to stop scan'}), 400
 
 
-@api_bp.route('/stopscan', methods=['POST'])
-def stopscan():
-    if lib.TriggerStopScan():
-        return '', 204
-    return jsonify({'error': 'unable to trigger stop scan'}), 400
-
-
 @api_bp.route('/config', methods=['POST'])
 def update_config():
     data = request.get_json(force=True)

--- a/web/backend.py
+++ b/web/backend.py
@@ -31,7 +31,6 @@ try:
     atexit.register(lib.Shutdown)
     lib.StartScan.restype = ctypes.c_bool
     lib.StopScan.restype = ctypes.c_bool
-    lib.TriggerStopScan.restype = ctypes.c_bool
     lib.produceReport.argtypes = [ctypes.c_bool]
     lib.produceReport.restype = ctypes.c_char_p
     lib.SetChunkOptions.argtypes = [ctypes.c_int, ctypes.c_int]

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -170,26 +170,21 @@
         await updateStatusAndRecordings();
       }
 
-      async function stopRec(){
-        try {
-          let res = await fetch('/api/stop_scan',{method:'POST'});
-          let data = res.status === 204 ? {status:'stopped'} : await res.json();
-          showMessage(res.ok, data.status || data.error || 'stopped');
-          if(!res.ok){
-            res = await fetch('/api/stopscan',{method:'POST'});
-            data = res.status === 204 ? {status:'stopped'} : await res.json();
+        async function stopRec(){
+          try {
+            const res = await fetch('/api/stop_scan',{method:'POST'});
+            const data = res.status === 204 ? {status:'stopped'} : await res.json();
             showMessage(res.ok, data.status || data.error || 'stopped');
+          } catch(err){
+            showMessage(false, err.message || 'failed to contact server');
           }
-        } catch(err){
-          showMessage(false, err.message || 'failed to contact server');
+          try {
+            await updateStatusAndRecordings();
+          } finally {
+            document.getElementById('start_btn').disabled = false;
+            document.getElementById('stop_btn').disabled = true;
+          }
         }
-        try {
-          await updateStatusAndRecordings();
-        } finally {
-          document.getElementById('start_btn').disabled = false;
-          document.getElementById('stop_btn').disabled = true;
-        }
-      }
 
       function showMessage(success, message){
         const msg = document.getElementById('messages');


### PR DESCRIPTION
## Summary
- drop unused `/stopscan` API and TriggerStopScan binding
- simplify stop action to call `/api/stop_scan` only

## Testing
- `python -m py_compile web/api.py web/backend.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a25bce6c8832aa9f9cf6f6e619842