### PR TITLE
Add UI control for static IP setup script

### DIFF
--- a/web/api.py
+++ b/web/api.py
@@ -2,6 +2,7 @@ import ctypes
 import json
 import os
 import time
+import subprocess
 import zmq
 from collections import deque
 from flask import Blueprint, Response, jsonify, current_app
@@ -42,6 +43,16 @@ def stopscan():
     if lib.TriggerStopScan():
         return '', 204
     return jsonify({'error': 'unable to trigger stop scan'}), 400
+
+
+@api_bp.route('/setup_static_ip', methods=['POST'])
+def setup_static_ip():
+    script = os.path.join(os.path.dirname(__file__), '..', 'scripts', 'ds_setup_static_ip.sh')
+    try:
+        subprocess.run([script], check=True)
+        return '', 204
+    except subprocess.CalledProcessError as exc:
+        return jsonify({'error': 'static ip setup failed', 'details': str(exc)}), 500
 
 
 def zmq_event_stream(port):

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -22,7 +22,12 @@
       <div class="d-flex flex-wrap gap-2 mb-3 justify-content-center align-items-center">
         <button class="btn btn-primary" @click="sendCommand('/api/start_scan')" :disabled="loading">Start Scan</button>
         <button class="btn btn-warning" @click="sendCommand('/api/stop_scan')" :disabled="loading">Stop Scan</button>
-        <button class="btn btn-danger" @click="sendCommand('/api/stopscan')" :disabled="loading">Trigger Stop Scan</button>
+        <button class="btn btn-danger" @click="sendCommand('/api/stopscan')" :disabled="loading">
+          Trigger Stop Scan
+        </button>
+        <button class="btn btn-secondary" @click="sendCommand('/api/setup_static_ip')" :disabled="loading">
+          Setup Static IP
+        </button>
         <div v-if="loading" class="spinner-border spinner-border-sm text-secondary" role="status">
           <span class="visually-hidden">Loading...</span>
         </div>


### PR DESCRIPTION
## Summary
- expose `/api/setup_static_ip` endpoint to run static IP setup script
- add "Setup Static IP" button in UI to trigger script

## Testing
- `python -m py_compile web/api.py`
- `pytest -q` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689a3f0538cc832aa725304274cf60ea