### PR TITLE
Remove static lidar configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,7 @@ The project relies on the following packages (installed by
    third‑party libraries, and builds the application. Reboot after completion
    to apply any USB automount or network changes.
 
-2. Edit configuration settings in
-   [`config/mandeye_config.json`](config/mandeye_config.json) to match your
-   environment (see **Configuration** below).
-
-3. (Optional) Start the systemd service immediately:
+2. (Optional) Start the systemd service immediately:
 
    ```bash
    sudo systemctl start mandeye.service
@@ -66,36 +62,16 @@ The project relies on the following packages (installed by
    sudo systemctl disable --now mandeye.service
    ```
 
-4. Launch the web interface manually (useful for development):
+3. Launch the web interface manually (useful for development):
 
    ```bash
    scripts/run_web.sh
    ```
 
-   The UI is available on `http://localhost:5000` unless overridden by the
-   `WEB_PORT` environment variable or configuration file.
+   The UI is available on `http://localhost:5000`.
 
-## Configuration
-
-Runtime settings are loaded from `config/mandeye_config.json` at startup. The
-file supports the following fields:
-
-* `livox_interface_ip` – Livox interface IP address (default auto-detected
-  from the available network interfaces).
-* `repository_path` – Path to USB repository (default `"/media/usb/"`).
-* `server_port` – Port used by the C++ publisher (default `8003`).
-* `web_port` – Port for the Flask web UI (default `5000`).
-
-For each setting the application uses the following precedence:
-
-1. Value from the configuration file
-2. Environment variable override (`MANDEYE_LIVOX_LISTEN_IP`,
-   `MANDEYE_REPO`, `SERVER_PORT`, `WEB_PORT`)
-3. Compiled default embedded in the binaries
-
-Modify the configuration file or set environment variables as needed before
-starting the application. After making changes, restart any running
-instances for the new settings to take effect.
+Outputs are stored in `/media/usb`, the web interface listens on port `5000`,
+and the Livox lidar interface IP is automatically determined from `eth0`.
 
 ## Common operations
 
@@ -134,8 +110,6 @@ curl http://localhost:5000/api/status_full  # detailed
 * **No status updates** – check that the publisher port (`server_port`) is
   open and not blocked by a firewall.
 
-Edit the configuration file or set environment variables as needed before
-starting the application.
 
 ## Docker
 
@@ -146,9 +120,7 @@ scripts/build_docker.sh
 scripts/run_docker.sh
 ```
 
-The run script exposes the web interface on port `5000` and mounts the
-`config` directory into the container so you can edit `config/mandeye_config.json`
-on the host and have those settings applied inside the container.
+The run script exposes the web interface on port `5000`.
 
 ## Logging
 

--- a/code/main.cpp
+++ b/code/main.cpp
@@ -676,35 +676,7 @@ int getEnvInt(const std::string& env, int def)
 MandeyeConfig LoadConfig()
 {
         MandeyeConfig cfg;
-        cfg.livox_interface_ip = utils::getEnvString("MANDEYE_LIVOX_LISTEN_IP", cfg.livox_interface_ip);
-        cfg.repository_path = utils::getEnvString("MANDEYE_REPO", cfg.repository_path);
         cfg.server_port = utils::getEnvInt("SERVER_PORT", cfg.server_port);
-
-        std::ifstream f("config/mandeye_config.json");
-        if(f)
-        {
-                try
-                {
-                        nlohmann::json j;
-                        f >> j;
-                        if(j.contains("livox_interface_ip") && j["livox_interface_ip"].is_string())
-                        {
-                                cfg.livox_interface_ip = j["livox_interface_ip"].get<std::string>();
-                        }
-                        if(j.contains("repository_path") && j["repository_path"].is_string())
-                        {
-                                cfg.repository_path = j["repository_path"].get<std::string>();
-                        }
-                        if(j.contains("server_port") && j["server_port"].is_number_integer())
-                        {
-                                cfg.server_port = j["server_port"].get<int>();
-                        }
-                }
-                catch(...)
-                {
-                        // ignore parse errors
-                }
-        }
         return cfg;
 }
 

--- a/code/utils/network.cpp
+++ b/code/utils/network.cpp
@@ -25,15 +25,14 @@ namespace utils
                                 auto* in = reinterpret_cast<sockaddr_in*>(ifa->ifa_addr);
                                 if(inet_ntop(AF_INET, &in->sin_addr, addr, sizeof(addr)))
                                 {
-                                        std::string candidate(addr);
-                                        if(candidate.rfind("192.168.", 0) == 0)
+                                        if(std::string(ifa->ifa_name) == "eth0")
                                         {
-                                                ip = candidate;
+                                                ip = addr;
                                                 break;
                                         }
                                         if(ip.empty())
                                         {
-                                                ip = candidate;
+                                                ip = addr;
                                         }
                                 }
                         }

--- a/config/mandeye_config.json
+++ b/config/mandeye_config.json
@@ -1,6 +1,0 @@
-{
-  "livox_interface_ip": "192.168.6.2",
-  "repository_path": "/media/usb/",
-  "server_port": 8003,
-  "web_port": 5000
-}

--- a/scripts/ds_setup_service.sh
+++ b/scripts/ds_setup_service.sh
@@ -10,11 +10,7 @@ if [[ -f "$SERVICE_FILE" ]]; then
   exit 0
 fi
 
-if command -v jq >/dev/null 2>&1; then
-  WEB_PORT="$(jq -r '.web_port // 5000' "${ROOT_DIR}/config/mandeye_config.json" 2>/dev/null)"
-else
-  WEB_PORT="5000"
-fi
+WEB_PORT="5000"
 
 PYTHON_BIN="${ROOT_DIR}/.venv/bin/python"
 if [[ ! -x "$PYTHON_BIN" ]]; then

--- a/scripts/run_docker.sh
+++ b/scripts/run_docker.sh
@@ -5,9 +5,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="${SCRIPT_DIR}/.."
 
 IMAGE_NAME="mandeye_tec:latest"
-CONFIG_DIR="${ROOT_DIR}/config"
 
-# Map web port and configuration directory
-WEB_PORT="${WEB_PORT:-5000}"
+# Map web port
+WEB_PORT="5000"
 
-docker run --rm -it -p "$WEB_PORT:$WEB_PORT" -v "${CONFIG_DIR}:/app/config" "$IMAGE_NAME"
+docker run --rm -it -p "$WEB_PORT:$WEB_PORT" "$IMAGE_NAME"

--- a/scripts/run_web.sh
+++ b/scripts/run_web.sh
@@ -17,8 +17,7 @@ if [ ! -d "$VENV_DIR" ]; then
   "$VENV_DIR/bin/pip" install -r "${ROOT_DIR}/requirements.txt"
 fi
 
-WEB_PORT="${WEB_PORT:-5000}"
-export WEB_PORT
+WEB_PORT="5000"
 
 cd "${ROOT_DIR}/web"
 "${VENV_DIR}/bin/flask" --app app run --host=0.0.0.0 --port "$WEB_PORT"

--- a/web/app.py
+++ b/web/app.py
@@ -1,20 +1,16 @@
-import os
 from flask import Flask
-from backend import config
 from api import api_bp
 from ui import ui_bp
 
+
 def create_app() -> Flask:
     app = Flask(__name__)
-    app.config.update(config)
     app.register_blueprint(api_bp)
     app.register_blueprint(ui_bp)
     return app
 
+
 app = create_app()
 
 if __name__ == "__main__":
-    port = config.get("web_port")
-    if port is None:
-        port = int(os.environ.get("WEB_PORT", 5000))
-    app.run(host="0.0.0.0", port=port)
+    app.run(host="0.0.0.0", port=5000)

--- a/web/backend.py
+++ b/web/backend.py
@@ -5,19 +5,6 @@ import json
 import threading
 import time
 
-CONFIG_PATH = os.path.join(os.path.dirname(__file__), '..', 'config', 'mandeye_config.json')
-
-
-def load_config():
-    try:
-        with open(CONFIG_PATH) as f:
-            return json.load(f)
-    except OSError:
-        return {}
-
-
-config = load_config()
-
 LIB_PATH = os.path.join(os.path.dirname(__file__), '..', 'build', 'libmandeye_core.so')
 lib = ctypes.CDLL(LIB_PATH)
 


### PR DESCRIPTION
## Summary
- Drop JSON-based configuration file and rely on fixed repository path and web port
- Auto-detect Livox interface IP from eth0 and simplify start-up scripts
- Trim Flask app and helpers after config removal

## Testing
- `python -m py_compile web/backend.py web/app.py`
- `bash -n scripts/ds_setup_service.sh scripts/run_web.sh scripts/run_docker.sh`
- `cmake -S . -B build` *(fails: Could not find LIVOX_SDK_INCLUDE_DIR)*

------
https://chatgpt.com/codex/tasks/task_e_689a411cc89c832aac5c86741be06a67