### PR TITLE
Refactor imports in API module

### DIFF
--- a/web/api.py
+++ b/web/api.py
@@ -1,10 +1,6 @@
-import ctypes
-import json
-import os
-import time
-import subprocess
-import zmq
+import os, json, ctypes, subprocess, time
 from collections import deque
+import zmq
 from flask import Blueprint, Response, jsonify, current_app
 from backend import lib, status_cache
 


### PR DESCRIPTION
## Summary
- consolidate API imports for clarity and ensure all used symbols are imported

## Testing
- `pytest`
- `python -m py_compile web/api.py`


------
https://chatgpt.com/codex/tasks/task_e_689a4a6d638c832aba84e5852fa63d64