### PR TITLE
chore: import ctypes in backend

### DIFF
--- a/web/backend.py
+++ b/web/backend.py
@@ -1,9 +1,9 @@
-import ctypes
 import os
 import atexit
 import json
 import threading
 import time
+import ctypes
 
 LIB_PATH = os.path.join(os.path.dirname(__file__), '..', 'build', 'libmandeye_core.so')
 lib = ctypes.CDLL(LIB_PATH)


### PR DESCRIPTION
## Summary
- ensure ctypes is imported alongside other top-level imports in backend

## Testing
- `python web/app.py` *(fails: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689a4a713b0c832a95c6cc0975894675