### PR TITLE
feat: add depth and size options to directory listing

### DIFF
--- a/code/FileSystemClient.h
+++ b/code/FileSystemClient.h
@@ -5,6 +5,8 @@
 #include <json.hpp>
 #include <mutex>
 #include <string>
+#include <vector>
+#include <functional>
 
 namespace mandeye
 {
@@ -30,7 +32,9 @@ public:
 	//! Get is writable
 	bool GetIsWritable();
 
-	std::vector<std::string> GetDirectories();
+        std::vector<std::string> GetDirectories(int maxDepth = -1,
+                                               bool includeFileSizes = true,
+                                               std::function<void(const std::string&)> onEntry = nullptr);
 
 	bool CreateDirectoryForContinousScanning(std::string &, const int &);
 


### PR DESCRIPTION
## Summary
- allow callers to limit depth and file size gathering when listing repository entries
- support streaming directory entries via optional callback
- update status report to use shallow, size-less directory listing

## Testing
- `cmake .. && make -j4` *(fails: Could not find LIVOX_SDK_INCLUDE_DIR using the following files: livox_lidar_def.h)*

------
https://chatgpt.com/codex/tasks/task_e_689a4a7e2a8c832a81423a49991f0034